### PR TITLE
アプリのエラーメッセージ日本語表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,4 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 gem 'payjp'
 gem 'aws-sdk-s3', require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -326,6 +329,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,9 @@ class Item < ApplicationRecord
   validates :title, :images, presence: true
   validates :description, presence: true, length: { maximum: 1000 }
 
-  with_options presence: true, numericality: { other_than: 1 } do
+  with_options presence: true,
+               numericality: { other_than: 1,
+               message: 'を選択してください' } do
     validates :category_id
     validates :condition_id
     validates :postage_id

--- a/app/models/payment_place.rb
+++ b/app/models/payment_place.rb
@@ -4,7 +4,7 @@ class PaymentPlace
 
   with_options presence: true do
     validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'はハイフンを含む半角数字7桁で入力してください' }
-    validates :city, format: { with: /\A[ぁ-んァ-ン一-龥々]/, message: 'は全角で記入してください' }
+    validates :city, format: { with: /\A[ぁ-んァ-ン一-龥々]/, message: 'は全角日本語で記入してください' }
     validates :block, format: { with: /\A[ぁ-んァ-ン一-龥々0-9-ー]/, message: 'は全角日本語および半角数字で記入してください' }
     validates :phone_number, format: { with: /\A\d{10,11}\z/, message: 'は半角数字10〜11桁（ハイフンなし）で記入してください' }
     validates :prefecture_id, numericality: { other_than: 1, message: 'を選択してください' }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,12 +9,12 @@ class User < ApplicationRecord
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
   validates_format_of :password, with: PASSWORD_REGEX, message: 'には半角を使用し、英字と数字の両方を含めて設定してください'
 
-  with_options presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々]+\z/, message: '：全角文字を使用してください' } do
+  with_options presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々]+\z/, message: 'は全角文字を使用してください' } do
     validates :family_name
     validates :first_name
   end
 
-  with_options presence: true, format: { with: /\A[ァ-ヶ]+\z/, message: '：全角文字を使用してください' } do
+  with_options presence: true, format: { with: /\A[ァ-ヶ]+\z/, message: 'は全角文字を使用してください' } do
     validates :family_name_reading, presence: true
     validates :first_name_reading, presence: true
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Furima32393
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメールの変更（%{email}）をお知らせいたします。
+        message_unconfirmed:
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,29 @@
+ja:
+ activerecord:
+   attributes:
+     user:
+       nickname: ニックネーム
+       birthday: 誕生日
+       family_name: お名前(苗字)
+       family_name_reading: お名前カナ(苗字)
+       first_name: お名前
+       first_name_reading: お名前カナ
+     item:
+       title: 商品名
+       images: 画像
+       description: 商品の説明
+       category_id: カテゴリー
+       condition_id: 商品の状態
+       postage_id: 配送料の負担
+       prefecture_id: 発送元の地域
+       shipment_day_id: 発送までの日数
+       price: 販売価格
+ activemodel:
+   attributes:
+     payment_place:
+       post_code: 郵便番号
+       city: 市区町村
+       block: 番地
+       phone_number: 電話番号
+       prefecture_id: 都道府県
+       token: クレジットカード情報

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     association :user
 
     after(:build) do |item|
-      item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
+      item.images.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,75 +13,75 @@ RSpec.describe Item, type: :model do
     end
 
     context '商品出品ができない時' do
-      it '商品画像が1枚添付されていないと出品できない' do
-        @item.image = nil
+      it '商品画像が添付されていないと出品できない' do
+        @item.images = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include('画像を入力してください')
       end
       it '商品名が空では出品できない' do
         @item.title = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Title can't be blank")
+        expect(@item.errors.full_messages).to include('商品名を入力してください')
       end
       it '商品の説明が空では出品できない' do
         @item.description = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Description can't be blank")
+        expect(@item.errors.full_messages).to include('商品の説明を入力してください')
       end
       it 'カテゴリーが選択されていなければ出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category must be other than 1')
+        expect(@item.errors.full_messages).to include('カテゴリーを選択してください')
       end
       it '商品の状態が選択されていなければ出品できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Condition must be other than 1')
+        expect(@item.errors.full_messages).to include('商品の状態を選択してください')
       end
       it '配送料の負担についての情報が選択されていなければ出品できない' do
         @item.postage_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Postage must be other than 1')
+        expect(@item.errors.full_messages).to include('配送料の負担を選択してください')
       end
       it '発送元の地域が選択されていなければ出品できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
+        expect(@item.errors.full_messages).to include('発送元の地域を選択してください')
       end
       it '発送までの日数が選択されていなければ出品できない' do
         @item.shipment_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Shipment day must be other than 1')
+        expect(@item.errors.full_messages).to include('発送までの日数を選択してください')
       end
       it '価格が空では出品できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank", 'Price は半角数字を使用し、300から9,999,999の間で入力してください')
+        expect(@item.errors.full_messages).to include('販売価格を入力してください')
       end
       it '価格が¥300より小さければ出品できない' do
         @item.price = 100
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price は半角数字を使用し、300から9,999,999の間で入力してください')
+        expect(@item.errors.full_messages).to include('販売価格は半角数字を使用し、300から9,999,999の間で入力してください')
       end
       it '価格が¥9,999,999より大きければ出品できない' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price は半角数字を使用し、300から9,999,999の間で入力してください')
+        expect(@item.errors.full_messages).to include('販売価格は半角数字を使用し、300から9,999,999の間で入力してください')
       end
       it '価格が全角では出品できない' do
         @item.price = '５０００'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price は半角数字を使用し、300から9,999,999の間で入力してください')
+        expect(@item.errors.full_messages).to include('販売価格は半角数字を使用し、300から9,999,999の間で入力してください')
       end
       it '価格が英字では出品できない' do
         @item.price = 'aaaa'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price は半角数字を使用し、300から9,999,999の間で入力してください')
+        expect(@item.errors.full_messages).to include('販売価格は半角数字を使用し、300から9,999,999の間で入力してください')
       end
       it '価格が半角英数混合では出品できない' do
         @item.price = '1m2N3b4V'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price は半角数字を使用し、300から9,999,999の間で入力してください')
+        expect(@item.errors.full_messages).to include('販売価格は半角数字を使用し、300から9,999,999の間で入力してください')
       end
     end
   end

--- a/spec/models/payment_place_spec.rb
+++ b/spec/models/payment_place_spec.rb
@@ -24,88 +24,87 @@ RSpec.describe PaymentPlace, type: :model do
     it '郵便番号が空では保存できない' do
       @payment_place.post_code = ''
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include("Post code can't be blank", 'Post code はハイフンを含む半角数字7桁で入力してください')
+      expect(@payment_place.errors.full_messages).to include('郵便番号を入力してください')
     end
     it '都道府県が選択されていなければ保存できない' do
       @payment_place.prefecture_id = 1
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('Prefecture を選択してください')
+      expect(@payment_place.errors.full_messages).to include('都道府県を選択してください')
     end
     it '市町村が空では保存できない' do
       @payment_place.city = ''
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include("City can't be blank", 'City は全角で記入してください')
+      expect(@payment_place.errors.full_messages).to include('市区町村を入力してください')
     end
     it '番地が空では保存できない' do
       @payment_place.block = ''
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include("Block can't be blank", 'Block は全角日本語および半角数字で記入してください')
+      expect(@payment_place.errors.full_messages).to include('番地を入力してください')
     end
     it '電話番号が空では保存できない' do
       @payment_place.phone_number = ''
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include("Phone number can't be blank",
-                                                             'Phone number は半角数字10〜11桁（ハイフンなし）で記入してください')
+      expect(@payment_place.errors.full_messages).to include('電話番号を入力してください')
     end
     it 'user_idがなければ保存できない' do
       @payment_place.user_id = ''
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include("User can't be blank")
+      expect(@payment_place.errors.full_messages).to include('Userを入力してください')
     end
     it 'item_idがなければ保存できない' do
       @payment_place.item_id = ''
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include("Item can't be blank")
+      expect(@payment_place.errors.full_messages).to include('Itemを入力してください')
     end
     it 'item_priceがなければ保存できない' do
       @payment_place.item_price = ''
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include("Item price can't be blank")
+      expect(@payment_place.errors.full_messages).to include('Item priceを入力してください')
     end
     it '郵便番号は半角数字でなければ保存できない' do
       @payment_place.post_code = '１２３-４５６７'
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('Post code はハイフンを含む半角数字7桁で入力してください')
+      expect(@payment_place.errors.full_messages).to include('郵便番号はハイフンを含む半角数字7桁で入力してください')
     end
     it '郵便番号はハイフンを含まなければ保存できない' do
       @payment_place.post_code = '1234567'
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('Post code はハイフンを含む半角数字7桁で入力してください')
+      expect(@payment_place.errors.full_messages).to include('郵便番号はハイフンを含む半角数字7桁で入力してください')
     end
     it '郵便番号は3桁＋4桁でなければ保存できない' do
       @payment_place.post_code = '1234-567'
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('Post code はハイフンを含む半角数字7桁で入力してください')
+      expect(@payment_place.errors.full_messages).to include('郵便番号はハイフンを含む半角数字7桁で入力してください')
     end
     it '市町村は全角でなければ保存できない' do
       @payment_place.city = 'ﾖｺﾊﾏｼﾐﾄﾞﾘｸ'
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('City は全角で記入してください')
+      expect(@payment_place.errors.full_messages).to include('市区町村は全角日本語で記入してください')
     end
     it '市町村は全角でも、日本語でなければ保存できない' do
       @payment_place.city = 'Ｍｉｄｏｒｉ－Ｗａｒｄ　Ｙｏｋｏｈａｍａ－Ｃｉｔｙ'
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('City は全角で記入してください')
+      expect(@payment_place.errors.full_messages).to include('市区町村は全角日本語で記入してください')
     end
     it '番地は全角日本語および半角数字以外では保存できない' do
       @payment_place.block = 'ΘψΔη１ー１ー１'
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('Block は全角日本語および半角数字で記入してください')
+      expect(@payment_place.errors.full_messages).to include('番地は全角日本語および半角数字で記入してください')
     end
     it '電話番号は10桁または11桁でなければ保存できない' do
       @payment_place.phone_number = '090112233445566778899'
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('Phone number は半角数字10〜11桁（ハイフンなし）で記入してください')
+      expect(@payment_place.errors.full_messages).to include('電話番号は半角数字10〜11桁（ハイフンなし）で記入してください')
     end
     it '電話番号は10桁または11桁でも半角数字でなければ保存できない' do
       @payment_place.phone_number = '０９０１２３４５６７８'
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include('Phone number は半角数字10〜11桁（ハイフンなし）で記入してください')
+      expect(@payment_place.errors.full_messages).to include('電話番号は半角数字10〜11桁（ハイフンなし）で記入してください')
     end
     it 'tokenが空では保存できない' do
       @payment_place.token = nil
       @payment_place.valid?
-      expect(@payment_place.errors.full_messages).to include("Token can't be blank")
+      expect(@payment_place.errors.full_messages).to include('クレジットカード情報を入力してください')
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,110 +21,110 @@ RSpec.describe User, type: :model do
       it 'ニックネームが空では登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Nickname can't be blank"
+        expect(@user.errors.full_messages).to include 'ニックネームを入力してください'
       end
       it 'メールアドレスが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email can't be blank"
+        expect(@user.errors.full_messages).to include 'Eメールを入力してください'
       end
       it 'パスワードが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password can't be blank"
+        expect(@user.errors.full_messages).to include 'パスワードを入力してください'
       end
       it 'パスワードが存在してもパスワード(確認用)が空では登録できない' do
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
+        expect(@user.errors.full_messages).to include 'パスワード（確認用）とパスワードの入力が一致しません'
       end
       it 'ユーザー本名の苗字が空では登録できない' do
         @user.family_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Family name can't be blank"
+        expect(@user.errors.full_messages).to include 'お名前(苗字)を入力してください'
       end
       it 'ユーザー本名の名前が空では登録できない' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name can't be blank"
+        expect(@user.errors.full_messages).to include 'お名前を入力してください'
       end
       it 'ユーザー本名の苗字フリガナが空では登録できない' do
         @user.family_name_reading = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Family name reading can't be blank"
+        expect(@user.errors.full_messages).to include 'お名前カナ(苗字)を入力してください'
       end
       it 'ユーザー本名の名前フリガナが空では登録できない' do
         @user.first_name_reading = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name reading can't be blank"
+        expect(@user.errors.full_messages).to include 'お名前カナを入力してください'
       end
       it '生年月日が空では登録できない' do
         @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Birthday can't be blank"
+        expect(@user.errors.full_messages).to include '誕生日を入力してください'
       end
       it '既にDBに存在するメールアドレスでは登録できない' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include 'Email has already been taken'
+        expect(another_user.errors.full_messages).to include 'Eメールはすでに存在します'
       end
       it '@を含まないメールアドレスでは登録できない' do
         @user.email.slice!('@')
         @user.email = @user.email
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Email is invalid'
+        expect(@user.errors.full_messages).to include 'Eメールは不正な値です'
       end
       it 'パスワードが5文字以下では登録できない' do
         @user.password = 'a1a1a'
         @user.password_confirmation = 'a1a1a'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
+        expect(@user.errors.full_messages).to include 'パスワードは6文字以上で入力してください'
       end
       it 'パスワードが6文字以上でも半角英字のみでは登録できない' do
         @user.password = 'aaaaaa'
         @user.password_confirmation = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password には半角を使用し、英字と数字の両方を含めて設定してください'
+        expect(@user.errors.full_messages).to include 'パスワードには半角を使用し、英字と数字の両方を含めて設定してください'
       end
       it 'パスワードが6文字以上でも半角数字のみでは登録できない' do
         @user.password = '000000'
         @user.password_confirmation = '000000'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password には半角を使用し、英字と数字の両方を含めて設定してください'
+        expect(@user.errors.full_messages).to include 'パスワードには半角を使用し、英字と数字の両方を含めて設定してください'
       end
       it 'パスワードが全角では登録できない' do
         @user.password = '１ａ１ａ１ａ'
         @user.password_confirmation = '１ａ１ａ１ａ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password には半角を使用し、英字と数字の両方を含めて設定してください'
+        expect(@user.errors.full_messages).to include 'パスワードには半角を使用し、英字と数字の両方を含めて設定してください'
       end
       it 'パスワードとパスワード(確認用)が不一致では登録できない' do
         @user.password = 'abc123'
         @user.password_confirmation = 'a1b2c3'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
+        expect(@user.errors.full_messages).to include 'パスワード（確認用）とパスワードの入力が一致しません'
       end
       it 'ユーザー本名の苗字が半角では登録できない' do
         @user.family_name = 'Jordison'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Family name ：全角文字を使用してください'
+        expect(@user.errors.full_messages).to include 'お名前(苗字)は全角文字を使用してください'
       end
       it 'ユーザー本名の名前が半角では登録できない' do
         @user.first_name = 'Joey'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name ：全角文字を使用してください'
+        expect(@user.errors.full_messages).to include 'お名前は全角文字を使用してください'
       end
       it 'ユーザー本名の苗字フリガナが半角では登録できない' do
         @user.family_name_reading = 'ｼﾞｮｰﾃﾞｨｿﾝ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Family name reading ：全角文字を使用してください'
+        expect(@user.errors.full_messages).to include 'お名前カナ(苗字)は全角文字を使用してください'
       end
       it 'ユーザー本名の名前フリガナが半角では登録できない' do
         @user.first_name_reading = 'ｼﾞｮｰｲ'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name reading ：全角文字を使用してください'
+        expect(@user.errors.full_messages).to include 'お名前カナは全角文字を使用してください'
       end
     end
   end


### PR DESCRIPTION
# what
アプリ内での入力が適切でなかった時に表示されるエラーメッセージを、日本語表記に変更した

# why
エラーメッセージで提示される箇所の表記を入力欄の表記に合わせ、どこが不適切なのかすぐにわかるようにした